### PR TITLE
Simple Intro Skip with Jump

### DIFF
--- a/SkipTheIntro/DllMain.cpp
+++ b/SkipTheIntro/DllMain.cpp
@@ -5,105 +5,26 @@
 using namespace ModUtils;
 
 HWND eldenRingWindow = NULL;
-HWND antiFlashbangWindow = NULL;
-
-extern "C" {
-	void OnIntroSkipped();
-	uintptr_t returnAddress = 0;
-	unsigned char introSkipped = 0;
-}
-
-void ShowAntiFlashbangWindow()
-{
-	HINSTANCE hInstance = GetModuleHandleA(GetModuleName().c_str());
-	const char className[] = "AntiFlashbang";
-	WNDCLASSEX wc;
-
-	wc.cbSize = sizeof(WNDCLASSEX);
-	wc.style = CS_HREDRAW | CS_VREDRAW;
-	wc.lpfnWndProc = DefWindowProc;
-	wc.cbClsExtra = 0;
-	wc.cbWndExtra = 0;
-	wc.hInstance = hInstance;
-	wc.hIcon = NULL;
-	wc.hCursor = LoadCursor(NULL, IDC_ARROW);
-	wc.hbrBackground = (HBRUSH)(COLOR_BTNTEXT + 1);
-	wc.lpszMenuName = NULL;
-	wc.lpszClassName = className;
-	wc.hIconSm = LoadIcon(NULL, IDI_APPLICATION);
-
-    RegisterClassEx(&wc);
-	antiFlashbangWindow = CreateWindowEx(
-		NULL,
-		className,
-		"Anti-flashbang window",
-		WS_POPUP,
-		CW_USEDEFAULT, 
-		CW_USEDEFAULT, 
-		0,
-		0,
-		NULL,
-		NULL,
-		hInstance, 
-		NULL);
-
-	RECT eldenRingRect;
-	GetWindowRect(eldenRingWindow, &eldenRingRect);
-	int width = eldenRingRect.right - eldenRingRect.left;
-	int height = eldenRingRect.bottom - eldenRingRect.top;
-	int x = eldenRingRect.left;
-	int y = eldenRingRect.top;
-
-	SetParent(antiFlashbangWindow, eldenRingWindow);
-	SetWindowPos(antiFlashbangWindow, NULL, x, y, width, height, NULL);
-	ShowWindow(antiFlashbangWindow, SW_MAXIMIZE);
-	UpdateWindow(antiFlashbangWindow);
-}
-
 DWORD WINAPI MainThread(LPVOID lpParam)
 {
 	if (GetWindowHandle())
 	{
 		eldenRingWindow = muWindow;
 	}
-    ShowAntiFlashbangWindow();
 
 	Log("Activating SkipTheIntro...");
-	std::vector<uint16_t> pattern = { 0xc6, MASKED, MASKED, MASKED, MASKED, MASKED, 0x01, MASKED, 0x03, 0x00, 0x00, 0x00, MASKED, 0x8b, MASKED, 0xe8, MASKED, MASKED, MASKED, MASKED, 0xe9, MASKED, MASKED, MASKED, MASKED, MASKED, 0x8d };
-	std::vector<uint16_t> originalBytes = { 0x74 };
-	std::vector<uint8_t> newBytes = { 0x90, 0x90 };
+	std::vector<uint16_t> pattern = { 0x48, 0x8B, 0x90, MASKED, MASKED, MASKED, MASKED, 0x48, 0x85, 0xD2, 0x74, 0x07, 0xC6 };
+	std::vector<uint16_t> originalBytes = { 0x48, 0x8B, 0x90, 0x80, 0x00, 0x00, 0x00 };
+	std::vector<uint8_t> newBytes = { 0xE9, 0x1C, 0x00, 0x00, 0x00 };
 	uintptr_t patchAddress = SigScan(pattern);
 
 	if (patchAddress != 0)
 	{
-		patchAddress -= 60;
-
-		if (Replace(patchAddress, originalBytes, newBytes))
+		if (!Replace(patchAddress, originalBytes, newBytes))
 		{
-			patchAddress -= 31;
-			size_t size = 19;
-			MemCopy((uintptr_t)&OnIntroSkipped, patchAddress, size);
-			returnAddress = patchAddress + size;
-			Hook(patchAddress, (uintptr_t)&OnIntroSkipped, size - 14);
+			Log("PATCH FAILED");
 		}
 	}
-
-    Timer forceDestroyTimer(60000);
-    MSG msg;
-    while (GetMessage(&msg, NULL, 0, 0) > 0)
-    {
-		if (introSkipped || forceDestroyTimer.Check())
-		{
-			Log("Destroying window");
-			DestroyWindow(antiFlashbangWindow);
-			break;
-		}
-
-		TranslateMessage(&msg);
-		DispatchMessage(&msg);
-		Sleep(10);
-    }
-
 	CloseLog();
 	return 0;
 }


### PR DESCRIPTION
I  decided to reverse your method entirely and create my own method based on your initial research
- I could not get your method to compile. 
- transplanting your method to my internal debug resulted in a crash for me.

**CHANGES**
- Removed Extra Window
- Removed Detour

The sig scan now points to (currently) `eldenring.exe+0AB01EE`
The patch is now a simple jump from (currently) `eldenring.exe+0AB01EE` to `eldenring.exe+0AB020F`
It takes roughly 14seconds from launch to title screen
